### PR TITLE
chore: upgrade gosling.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.12.20",
-        "gosling.js": "^0.9.2"
+        "gosling.js": "^0.9.8"
       }
     },
     "node_modules/@babel/runtime": {
@@ -615,6 +615,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "peer": true
+    },
+    "node_modules/@types/bezier-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bezier-js/-/bezier-js-4.1.0.tgz",
+      "integrity": "sha512-ElU16s8E6Pr6magp8ihwH1O8pbUJASbMND/qgUc9RsLmP3lMLHiDMRXdjtaObwW5GPtOVYOsXDUIhTIluT+yaw=="
     },
     "node_modules/@types/d3": {
       "version": "5.16.4",
@@ -1446,6 +1451,15 @@
         }
       ],
       "peer": true
+    },
+    "node_modules/bezier-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-4.1.1.tgz",
+      "integrity": "sha512-oVOS6SSFFFlfnZdzC+lsfvhs/RRcbxJ47U04M4s5QIBaJmr3YWmTIL3qmrOK9uW+nUUcl9Jccmo/xpTrG+bBoQ==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
     },
     "node_modules/big-integer": {
       "version": "1.6.48",
@@ -4009,21 +4023,23 @@
       }
     },
     "node_modules/gosling-theme": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/gosling-theme/-/gosling-theme-0.0.7.tgz",
-      "integrity": "sha512-rXFeettHSzs117dPQqsQZj7IyujeKf3uvDXTlymQ1hQdDwQOP1p3yBrHMDwsBXvvwzRY3jwgkB9z7Su9jnWmHA=="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/gosling-theme/-/gosling-theme-0.0.9.tgz",
+      "integrity": "sha512-7CPVrmPCFFE08rk+tM6AxoT5agKALrBYpwU/bdeAxxXnA2Jwoenso8MOA+bYbmblpQ3WGQDlhcCyUi3I1jG3Aw=="
     },
     "node_modules/gosling.js": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/gosling.js/-/gosling.js-0.9.2.tgz",
-      "integrity": "sha512-52fSI9O46z7vOFh4zmfqbxZhIpf9HyeBuvC6/tXufSInlUQI+j+z6krMJ+RS/7Gs+JNBQlqtgiSFBd8RL7gf4A==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/gosling.js/-/gosling.js-0.9.8.tgz",
+      "integrity": "sha512-CyevfPnBS1czkRafFvXNiLUBgVQFVJyC04siXLc4ZY+ghjFAqG6DogaXNz9Q1tsk/go5leYgltItU7STdjzhWg==",
       "dependencies": {
-        "@gmod/bam": "^1.1.6",
+        "@gmod/bam": "^1.1.8",
         "@gmod/bbi": "^1.0.30",
+        "@types/bezier-js": "^4.1.0",
         "@types/d3": "^5.7.2",
         "@types/lodash": "^4.14.151",
         "@types/node": "^12.0.0",
         "@types/uuid": "^8.3.0",
+        "bezier-js": "^4.1.1",
         "box-intersect": "^1.0.2",
         "d3-array": "^2.5.1",
         "d3-color": "^2.0.0",
@@ -4033,7 +4049,7 @@
         "d3-shape": "^2.0.0",
         "file-loader": "^6.0.0",
         "generic-filehandle": "^2.0.3",
-        "gosling-theme": "0.0.7",
+        "gosling-theme": "0.0.9",
         "higlass": "^1.11.7",
         "higlass-register": "^0.3.0",
         "higlass-text": "^0.1.1",
@@ -4042,7 +4058,6 @@
         "lodash": "^4.17.15",
         "mixwith": "^0.1.1",
         "pubsub-js": "^1.9.3",
-        "raw-loader": "^4.0.2",
         "react-grid-layout": "^1.2.5",
         "threads": "^1.6.4",
         "worker-loader": "^3.0.8"
@@ -7052,25 +7067,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/raw-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
-      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
     "node_modules/react": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
@@ -9793,6 +9789,11 @@
         }
       }
     },
+    "@types/bezier-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bezier-js/-/bezier-js-4.1.0.tgz",
+      "integrity": "sha512-ElU16s8E6Pr6magp8ihwH1O8pbUJASbMND/qgUc9RsLmP3lMLHiDMRXdjtaObwW5GPtOVYOsXDUIhTIluT+yaw=="
+    },
     "@types/d3": {
       "version": "5.16.4",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
@@ -10537,6 +10538,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "peer": true
+    },
+    "bezier-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-4.1.1.tgz",
+      "integrity": "sha512-oVOS6SSFFFlfnZdzC+lsfvhs/RRcbxJ47U04M4s5QIBaJmr3YWmTIL3qmrOK9uW+nUUcl9Jccmo/xpTrG+bBoQ=="
     },
     "big-integer": {
       "version": "1.6.48",
@@ -12735,21 +12741,23 @@
       }
     },
     "gosling-theme": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/gosling-theme/-/gosling-theme-0.0.7.tgz",
-      "integrity": "sha512-rXFeettHSzs117dPQqsQZj7IyujeKf3uvDXTlymQ1hQdDwQOP1p3yBrHMDwsBXvvwzRY3jwgkB9z7Su9jnWmHA=="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/gosling-theme/-/gosling-theme-0.0.9.tgz",
+      "integrity": "sha512-7CPVrmPCFFE08rk+tM6AxoT5agKALrBYpwU/bdeAxxXnA2Jwoenso8MOA+bYbmblpQ3WGQDlhcCyUi3I1jG3Aw=="
     },
     "gosling.js": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/gosling.js/-/gosling.js-0.9.2.tgz",
-      "integrity": "sha512-52fSI9O46z7vOFh4zmfqbxZhIpf9HyeBuvC6/tXufSInlUQI+j+z6krMJ+RS/7Gs+JNBQlqtgiSFBd8RL7gf4A==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/gosling.js/-/gosling.js-0.9.8.tgz",
+      "integrity": "sha512-CyevfPnBS1czkRafFvXNiLUBgVQFVJyC04siXLc4ZY+ghjFAqG6DogaXNz9Q1tsk/go5leYgltItU7STdjzhWg==",
       "requires": {
-        "@gmod/bam": "^1.1.6",
+        "@gmod/bam": "^1.1.8",
         "@gmod/bbi": "^1.0.30",
+        "@types/bezier-js": "^4.1.0",
         "@types/d3": "^5.7.2",
         "@types/lodash": "^4.14.151",
         "@types/node": "^12.0.0",
         "@types/uuid": "^8.3.0",
+        "bezier-js": "^4.1.1",
         "box-intersect": "^1.0.2",
         "d3-array": "^2.5.1",
         "d3-color": "^2.0.0",
@@ -12759,7 +12767,7 @@
         "d3-shape": "^2.0.0",
         "file-loader": "^6.0.0",
         "generic-filehandle": "^2.0.3",
-        "gosling-theme": "0.0.7",
+        "gosling-theme": "0.0.9",
         "higlass": "^1.11.7",
         "higlass-register": "^0.3.0",
         "higlass-text": "^0.1.1",
@@ -12768,7 +12776,6 @@
         "lodash": "^4.17.15",
         "mixwith": "^0.1.1",
         "pubsub-js": "^1.9.3",
-        "raw-loader": "^4.0.2",
         "react-grid-layout": "^1.2.5",
         "threads": "^1.6.4",
         "worker-loader": "^3.0.8"
@@ -15351,15 +15358,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raw-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
-      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      }
     },
     "react": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.1.0",
   "description": "An embed utility for gosling.js",
   "main": "gosling-embed.js",
-  "files": ["gosling-embed.js"],
+  "files": [
+    "gosling-embed.js"
+  ],
   "scripts": {
     "prepare": "npm run build",
     "build": "NODE_ENV=production node build"
@@ -13,6 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "esbuild": "^0.12.20",
-    "gosling.js": "^0.9.2"
+    "gosling.js": "^0.9.8"
   }
 }


### PR DESCRIPTION
Thank you for this useful module!

I wanted to test with the latest gosling.js in the observablehq. I just ran `npm add gosling.js` and wondering if this is the correct way since I see many package dependencies are now removed from `package-lock.json...